### PR TITLE
Add gte and lte operators

### DIFF
--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -44,6 +44,8 @@ pub enum Operator {
     NotEqual,
     GreaterThan,
     LessThan,
+    GreaterThanOrEqualTo,
+    LessThanOrEqualTo,
 }
 
 #[derive(PartialEq, Debug)]

--- a/parser/src/expr.rs
+++ b/parser/src/expr.rs
@@ -73,6 +73,8 @@ named!(
             | map!(tag!("^"), |_| Operator::Exponentiation)
             | map!(tag!("=="), |_| Operator::Equal)
             | map!(tag!("!="), |_| Operator::NotEqual)
+            | map!(tag!(">="), |_| Operator::GreaterThanOrEqualTo)
+            | map!(tag!("<="), |_| Operator::LessThanOrEqualTo)
             | map!(tag!(">"), |_| Operator::GreaterThan)
             | map!(tag!("<"), |_| Operator::LessThan)
     )
@@ -119,6 +121,8 @@ mod test {
         assert_eq!(operator(&b"!="[..]), Ok((&b""[..], Operator::NotEqual)));
         assert_eq!(operator(&b">"[..]), Ok((&b""[..], Operator::GreaterThan)));
         assert_eq!(operator(&b"<"[..]), Ok((&b""[..], Operator::LessThan)));
+        assert_eq!(operator(&b">="[..]), Ok((&b""[..], Operator::GreaterThanOrEqualTo)));
+        assert_eq!(operator(&b"<="[..]), Ok((&b""[..], Operator::LessThanOrEqualTo)));
     }
 
     #[test]

--- a/printer/src/js.rs
+++ b/printer/src/js.rs
@@ -69,6 +69,8 @@ fn print_operator(op: Operator) -> String {
         Operator::NotEqual => String::from("!="),
         Operator::GreaterThan => String::from(">"),
         Operator::LessThan => String::from("<"),
+        Operator::GreaterThanOrEqualTo => String::from(">="),
+        Operator::LessThanOrEqualTo => String::from("<="),
     }
 }
 


### PR DESCRIPTION
This is an awesome project. I hope you don't mind me taking a stab at #11. Added `>=` and `<=` comparison operators. 

I'm using `Operator::GreaterThanOrEqualTo` and `Operator::LessThanOrEqualTo` respectively instead of `Operator::Gte` and `Operator::Lte` because I thought they would be more consistent with `Operator::GreaterThan` and `Operator::LessThan`. What do you think?